### PR TITLE
Unify all the methods that are the same using params to pass currency

### DIFF
--- a/Controller/ProcessShapeShift.Controller.php
+++ b/Controller/ProcessShapeShift.Controller.php
@@ -37,9 +37,9 @@ class ProcessShapeShift extends Base
     public function get_ShapeShifter_Rates()
     {
         $prices = new Prices();
-        $viewData['ETH'] = $prices->getShapeShifterRate_ETH();
-        $viewData['XMR'] = $prices->getShapeShifterRate_XMR();
-        $viewData['DASH'] = $prices->getShapeShifterRate_DASH();
+        $viewData['ETH'] = $prices->getShapeShifterCurrencyRate('ETH');
+        $viewData['XMR'] = $prices->getShapeShifterCurrencyRate('XMR');
+        $viewData['DASH'] = $prices->getShapeShifterCurrencyRate('DASH');
 
         $this->render('Welcome', 'home.view', $viewData);
     }

--- a/Model/Prices.Model.php
+++ b/Model/Prices.Model.php
@@ -40,45 +40,11 @@ class Prices extends Base
         return $data;
     }
 
-    public function getShapeShifterRate_ETH()
+    public function getShapeShifterCurrencyRate($currency)
     {
         $sql = "SELECT * 
                 FROM `shapeshifter_rates`  
-                WHERE `coin` = 'BTC_ETH'
-                ORDER BY `id` DESC 
-                LIMIT 10
-                ";
-
-        $stm = $this->database->prepare(($sql), array(PDO::ATTR_CURSOR => PDO::CURSOR_FWDONLY));
-
-        $stm->execute();
-
-        $data = $stm->fetchAll(PDO::FETCH_ASSOC);
-
-        return $data;
-    }
-    public function getShapeShifterRate_XMR()
-    {
-        $sql = "SELECT * 
-                FROM `shapeshifter_rates`  
-                WHERE `coin` = 'BTC_XMR'
-                ORDER BY `id` DESC 
-                LIMIT 10
-                ";
-
-        $stm = $this->database->prepare(($sql), array(PDO::ATTR_CURSOR => PDO::CURSOR_FWDONLY));
-
-        $stm->execute();
-
-        $data = $stm->fetchAll(PDO::FETCH_ASSOC);
-
-        return $data;
-    }
-    public function getShapeShifterRate_DASH()
-    {
-        $sql = "SELECT * 
-                FROM `shapeshifter_rates`  
-                WHERE `coin` = 'BTC_DASH'
+                WHERE `coin` = 'BTC_".$currency."'
                 ORDER BY `id` DESC 
                 LIMIT 10
                 ";


### PR DESCRIPTION
As seen in commit: https://github.com/steveclifton/Shape-Shift-Updates/commit/474ee412a728d0f38c3081109c2ae7c93349b602 to change a small thing will currently need to be applied for 3 different functions (and more later if more currencies get added)

This PR will unify those methods into one and passing through the currency as a parameter instead, less code to maintain